### PR TITLE
fixed(#8):Improve spacing in Skills section subtitle and bullet points

### DIFF
--- a/src/containers/skills/Skills.scss
+++ b/src/containers/skills/Skills.scss
@@ -28,6 +28,7 @@
 }
 .subTitle {
   color: $subTitle;
+  margin-bottom: 8px;
 }
 
 /* Media Query */


### PR DESCRIPTION
- Updated `.subTitle` class in `Skills.scss` to include `margin-bottom: 8px`, enhancing visual separation and readability between bullet points.

Closes: https://github.com/hmedina24/Hector_Medina_portfolio_-2025/issues/8

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (8)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
