### PR TITLE
feat(header): update Resume tab to open Google Drive resume link in n…

### DIFF
--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -67,7 +67,13 @@ function Header() {
         )}
         {viewResume && (
           <li>
-            <a href="#resume">Resume</a>
+            <a
+              href="https://drive.google.com/file/d/1rcPWqW-SWC7AzX84VFs7jF4Zs0pznByE/view?usp=sharing"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Resume
+            </a>
           </li>
         )}
         <li>


### PR DESCRIPTION
feat(header): update Resume tab to open Google Drive resume link from tab 

- Changed the Resume tab anchor tag to point to hosted resume on Google Drive
- Added target="_blank" and rel="noopener noreferrer" for security and UX


fixed(https://github.com/hmedina24/Hector_Medina_portfolio_-2025/issues/2)

## Type of change

- [x] New feature (non-breaking change which adds functionality)