### PR TITLE
Add profile.json for open source section

### DIFF
--- a/src/containers/projects/Projects.js
+++ b/src/containers/projects/Projects.js
@@ -16,7 +16,7 @@ export default function Projects() {
 
   useEffect(() => {
     const getRepoData = () => {
-      fetch("/profile.json")
+      fetch("public/profile.json")
         .then(result => {
           if (result.ok) {
             return result.json();


### PR DESCRIPTION
# Description

When deploying the site to Netlify, the profile.json file was not being found at the expected path (/profile.json), resulting in a 404 Not Found error. This caused the Open Source Projects section to fail silently, throwing an object error and rendering no content in that section.

To resolve this, I updated the fetch path from /profile.json to public/profile.json in an attempt to align with the actual deployed file structure and ensure the file can be correctly accessed during runtime.

🛠 What’s Changed
Updated the fetch path to public/profile.json to help Netlify locate the file correctly during deployment.

Fixes # (https://github.com/hmedina24/Hector_Medina_portfolio_-2025/issues/3)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)