### PR TITLE
fix: temporarily disable Open Source section due to deployment issue

### DIFF
--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -176,8 +176,8 @@ const educationInfo = {
 To know how to get github key look at readme.md */
 
 const openSource = {
-  showGithubProfile: "true", // Set true or false to show Contact profile using Github, defaults to true
-  display: true // Set false to hide this section, defaults to true
+  showGithubProfile: "false", // Set true or false to show Contact profile using Github, defaults to true
+  display: false // Set false to hide this section, defaults to true
 };
 
 // Some big projects you have worked on


### PR DESCRIPTION
fix: temporarily disable Open Source section due to deployment issue reading profile.json (#3)

- Set `openSource.display` to false to hide the Open Source section for now
- Set `showGithubProfile` to "false" to prevent GitHub profile rendering
- This is a temporary fix while resolving a deployment issue where `profile.json` in the public directory is not being read correctly after deploying to Netlify

Fixes: https://github.com/hmedina24/Hector_Medina_portfolio_-2025/issues/3
Fixes # (3)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
